### PR TITLE
Replace Qt config dialog with web UI

### DIFF
--- a/config_dialog.py
+++ b/config_dialog.py
@@ -1,73 +1,16 @@
-# -*- coding: utf-8 -*-
-"""
-Created on Thu May 29 17:45:21 2025
-
-@author: windows
-"""
-
-import sys
-import json
 import os
-from PyQt6.QtWidgets import (
-    QApplication, QWidget, QVBoxLayout, QLabel, QLineEdit,
-    QPushButton, QHBoxLayout, QComboBox
-)
+import json
+import subprocess
+import sys
+import time
+import webbrowser
 
 CONFIG_FILE = "run_config.json"
 
 ROLES = [
-    "FLIGHT", "CAPCOM", "FAO", "BME", "CPOO", "SCIENCE", "EVA"
+    "FLIGHT", "CAPCOM", "FAO", "BME", "CPOO", "SCIENCE", "EVA",
 ]
 
-def get_config_from_dialog():
-    app = QApplication(sys.argv)
-    window = QWidget()
-    window.setWindowTitle("Mission Control Config")
-    layout = QVBoxLayout()
-
-    server_input = QLineEdit("comms.a.pinggy.link")
-    port_input = QLineEdit("23234")
-    botname_input = QLineEdit("CAPCOM")
-    role_select = QComboBox()
-    role_select.addItems(ROLES)
-
-    layout.addWidget(QLabel("Server address:"))
-    layout.addWidget(server_input)
-    layout.addWidget(QLabel("Server port:"))
-    layout.addWidget(port_input)
-    layout.addWidget(QLabel("Bot base name:"))
-    layout.addWidget(botname_input)
-    layout.addWidget(QLabel("Role:"))
-    layout.addWidget(role_select)
-
-    hbox = QHBoxLayout()
-    ok_btn = QPushButton("OK")
-    hbox.addStretch(1)
-    hbox.addWidget(ok_btn)
-    layout.addLayout(hbox)
-
-    window.setLayout(layout)
-
-    result = {}
-
-    def on_ok():
-        result['server'] = server_input.text().strip()
-        result['port'] = int(port_input.text().strip())
-        result['bot_base'] = botname_input.text().strip()
-        result['role'] = role_select.currentText()
-        with open(CONFIG_FILE, "w") as f:
-            json.dump(result, f)
-        window.close()
-        app.quit()
-
-    ok_btn.clicked.connect(on_ok)
-    window.show()
-    app.exec()
-
-    if not result and os.path.isfile(CONFIG_FILE):
-        with open(CONFIG_FILE, "r") as f:
-            result = json.load(f)
-    return result
 
 def read_config():
     if os.path.isfile(CONFIG_FILE):
@@ -75,6 +18,29 @@ def read_config():
             return json.load(f)
     return None
 
+
 def write_config(server, port, bot_base, role):
     with open(CONFIG_FILE, "w") as f:
-        json.dump({"server": server, "port": port, "bot_base": bot_base, "role": role}, f)
+        json.dump({
+            "server": server,
+            "port": port,
+            "bot_base": bot_base,
+            "role": role,
+        }, f)
+
+
+def get_config_from_dialog():
+    """Launch web-based config UI if no config file exists."""
+    cfg = read_config()
+    if cfg:
+        return cfg
+
+    server_py = os.path.join(os.path.dirname(__file__), "web_ui_server.py")
+    proc = subprocess.Popen([sys.executable, server_py, "--config-only"])
+    time.sleep(1)
+    webbrowser.open("http://127.0.0.1:8080/config")
+    print("Waiting for configuration via web UI...")
+    while not os.path.isfile(CONFIG_FILE):
+        time.sleep(1)
+    proc.terminate()
+    return read_config()

--- a/web_ui_server.py
+++ b/web_ui_server.py
@@ -1,17 +1,20 @@
 from flask import Flask, render_template_string, jsonify, request
-import json, os, requests, time
+import json, os, requests, time, sys
 
 # --------------------------------- configuration ---------------------------------
-from config_dialog import read_config
-config = read_config()
+from config_dialog import read_config, write_config
+config = read_config() or {}
 role = config.get("role", "FLIGHT")
-loop_file = os.path.join("LOOPS", f"loops_{role.upper()}.txt")
-try:
-    with open(loop_file, "r") as f:
-        LOOPS = json.load(f)
-except Exception as e:
-    print(f"Error loading {loop_file}: {e}")
-    LOOPS = []
+def load_loops(r):
+    lf = os.path.join("LOOPS", f"loops_{r.upper()}.txt")
+    try:
+        with open(lf, "r") as f:
+            return json.load(f)
+    except Exception as e:
+        print(f"Error loading {lf}: {e}")
+        return []
+
+LOOPS = load_loops(role)
 
 # --------------------------------- bot pool ---------------------------------
 BOTS = [
@@ -22,6 +25,13 @@ BOTS = [
 
 bot_pool = {b['name']: {'port': b['port'], 'assigned': None, 'last_used': 0} for b in BOTS}
 loop_states = {loop['name']: (0, None) for loop in LOOPS}  # state, bot
+
+def update_config(new_cfg):
+    global config, role, LOOPS, loop_states
+    config = new_cfg
+    role = config.get("role", "FLIGHT")
+    LOOPS = load_loops(role)
+    loop_states = {loop['name']: (0, None) for loop in LOOPS}
 
 def find_idle_bot():
     idle = [(n, d) for n, d in bot_pool.items() if d['assigned'] is None]
@@ -129,12 +139,71 @@ document.addEventListener('DOMContentLoaded',init);
 </html>
 """
 
+CONFIG_TEMPLATE = r"""
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+  <title>Setup</title>
+  <style>
+    body{font-family:sans-serif;background:#1e1e1e;color:#ddd;padding:40px}
+    input,select{margin:5px 0;padding:6px 8px;background:#2b2b2b;border:none;color:#ddd;border-radius:4px;width:100%}
+    button{padding:8px 14px;margin-top:10px;background:#3c6d2d;border:none;color:#fff;border-radius:4px}
+  </style>
+</head>
+<body>
+  <h2>Mission Control Config</h2>
+  <label>Server <input id='srv'></label>
+  <label>Port <input id='prt' type='number'></label>
+  <label>Bot Base <input id='bot'></label>
+  <label>Role
+    <select id='role'>
+      %s
+    </select>
+  </label>
+  <button id='save'>Save</button>
+  <script>
+    async function load(){
+      const cfg=await (await fetch('/api/get_config')).json();
+      document.getElementById('srv').value=cfg.server||'';
+      document.getElementById('prt').value=cfg.port||'';
+      document.getElementById('bot').value=cfg.bot_base||'';
+      document.getElementById('role').value=cfg.role||'FLIGHT';
+    }
+    async function save(){
+      const cfg={server:srv.value,port:parseInt(prt.value),bot_base:bot.value,role:role.value};
+      await fetch('/api/save_config',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(cfg)});
+      location.href='/';
+    }
+    document.getElementById('save').onclick=save;
+    document.addEventListener('DOMContentLoaded',load);
+  </script>
+</body>
+</html>
+""" % ("".join(f"<option value='{r}'>{r}</option>" for r in ['FLIGHT','CAPCOM','FAO','BME','CPOO','SCIENCE','EVA']))
+
 # --------------------------------- routes ---------------------------------
 @app.route('/')
 def index():
     rendered = TEMPLATE.replace('{{port}}', str(BOTS[0]['port'])) \
                        .replace('{{bots}}', json.dumps(BOTS))
     return render_template_string(rendered)
+
+@app.route('/config')
+def config_page():
+    return render_template_string(CONFIG_TEMPLATE)
+
+@app.route('/api/get_config')
+def get_config_api():
+    return jsonify(config)
+
+@app.route('/api/save_config', methods=['POST'])
+def save_config_api():
+    data = request.get_json(force=True)
+    write_config(data['server'], int(data['port']), data['bot_base'], data['role'])
+    update_config(data)
+    return '', 204
 
 @app.route('/api/config')
 def config_api():
@@ -208,4 +277,9 @@ def command_api():
 
 # --------------------------------- main ---------------------------------
 if __name__ == '__main__':
-    app.run(debug=True)
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config-only', action='store_true')
+    parser.add_argument('--port', type=int, default=8080)
+    args = parser.parse_args()
+    app.run(debug=True, port=args.port)


### PR DESCRIPTION
## Summary
- move configuration into the Flask UI
- provide `/config` page and REST endpoints for config storage
- update `start_all.py` to use the web based config flow

## Testing
- `python -m py_compile config_dialog.py web_ui_server.py start_all.py`

------
https://chatgpt.com/codex/tasks/task_e_684f10ed38b4832898db5965048e3a72