### PR TITLE
Fix delay button crash

### DIFF
--- a/bot_server.py
+++ b/bot_server.py
@@ -369,7 +369,8 @@ def users():
 
 @app.route('/delay_on', methods=['POST'])
 def delay_on():
-    seconds = request.json.get('seconds', 3)
+    data = request.get_json(silent=True) or {}
+    seconds = data.get('seconds', 3)
     bot.enable_audio_delay(seconds)
     return jsonify(ok=True)
 

--- a/web_ui_server.py
+++ b/web_ui_server.py
@@ -208,8 +208,12 @@ def command_api():
         for b in bot_pool.values():
             path = 'delay_on' if data.get('enabled') else 'delay_off'
             try:
-                requests.post(f"http://127.0.0.1:{b['port']}/{path}")
-            except:
+                # send an empty JSON body so bot_server doesn't crash when
+                # accessing request.json
+                requests.post(
+                    f"http://127.0.0.1:{b['port']}/{path}", json={}
+                )
+            except Exception:
                 pass
         return '', 204
 


### PR DESCRIPTION
## Summary
- send empty JSON from web_ui_server when calling bots for delay
- allow `/delay_on` endpoint to accept missing JSON bodies

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f43c7fd2c83288e463e1f2f5d98f3