### PR TITLE
Enable CORS on bot server

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This application **requires Python 3.11**. If you do not already have Python:
 
 1. Download or clone this repository.
 2. Open a terminal in the project folder.
-3. Install the required Python packages:
+3. Install the required Python packages (run again if you already installed earlier):
    ```bash
    python -m pip install -r requirements.txt
    ```

--- a/bot_server.py
+++ b/bot_server.py
@@ -8,6 +8,7 @@ import sounddevice as sd
 from flask import Flask, request, jsonify
 import signal
 import sys
+from flask_cors import CORS
 
 script_dir = os.path.dirname(__file__)
 os.add_dll_directory(script_dir)
@@ -318,6 +319,7 @@ class LoopBot:
 
 # --- FLASK API SERVER ---
 app = Flask(__name__)
+CORS(app)
 bot = LoopBot()
 
 @app.route('/status')

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sounddevice
 cryptography
 psutil
 pymumble
+flask-cors


### PR DESCRIPTION
## Summary
- add `flask-cors` to requirements
- import and activate `CORS` in `bot_server.py`
- note the dependency in the install instructions

## Testing
- `python -m py_compile bot_server.py`
- `python -m py_compile start_all.py web_ui_server.py config_dialog.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684f6bf111a483288a032b24a1e88dc5