### PR TITLE
Fix loop card text interfering with clicks

### DIFF
--- a/web_ui_server.py
+++ b/web_ui_server.py
@@ -74,7 +74,7 @@ MAIN_HTML = r"""
  .listen{background:var(--listen)} .talk{background:var(--talk)}
  .priv{position:absolute;top:8px;left:10px;font-size:1rem}
  .cnt{position:absolute;top:8px;right:10px;font-size:.9rem}
- .name{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);text-align:center;font-weight:600;padding:0 4px}
+.name{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);text-align:center;font-weight:600;padding:0 4px;user-select:none;pointer-events:none}
  .vol{position:absolute;bottom:10px;left:10px;width:55%}
  .off{position:absolute;bottom:6px;right:10px;padding:4px 10px;background:var(--danger);border:none;border-radius:4px;color:#fff;font-weight:600}
  #logo{position:fixed;bottom:10px;right:10px;height:60px;opacity:.6}


### PR DESCRIPTION
## Summary
- prevent clicks on loop names from selecting text or swallowing the card click

## Testing
- `python -m py_compile web_ui_server.py bot_server.py start_all.py config_dialog.py`

------
https://chatgpt.com/codex/tasks/task_e_684f705cba90832893f5b2a5b9ce2454