### PR TITLE
Fix Windows DLL loading

### DIFF
--- a/bot_server.py
+++ b/bot_server.py
@@ -11,7 +11,8 @@ import sys
 from flask_cors import CORS
 
 script_dir = os.path.dirname(__file__)
-os.add_dll_directory(script_dir)
+if hasattr(os, "add_dll_directory"):  # Windows only
+    os.add_dll_directory(script_dir)
 
 # --- Graceful Shutdown on SIGTERM/SIGINT ---
 def handle_exit(signum, frame):


### PR DESCRIPTION
## Summary
- conditionally call `os.add_dll_directory` so Linux environments don't fail

## Testing
- `python3 -m py_compile bot_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6850da73f2a48328a011bfecfbeceeb6